### PR TITLE
Filter: bugfix for shouldIgnorePath() ignoring paths containing the name of a standard

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -138,6 +138,12 @@ http://pear.php.net/dtd/package-2.0.xsd">
       <file baseinstalldir="" name="IsReferenceTest.inc" role="test" />
       <file baseinstalldir="" name="IsReferenceTest.php" role="test" />
      </dir>
+     <dir name="Filters">
+      <dir name="Filter">
+       <file baseinstalldir="" name="AcceptTest.xml" role="test" />
+       <file baseinstalldir="" name="AcceptTest.php" role="test" />
+      </dir>
+     </dir>
      <file baseinstalldir="" name="AllTests.php" role="test" />
      <file baseinstalldir="" name="ErrorSuppressionTest.php" role="test" />
      <file baseinstalldir="" name="IsCamelCapsTest.php" role="test" />
@@ -1856,6 +1862,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/GetMethodPropertiesTest.inc" name="tests/Core/File/GetMethodPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.php" name="tests/Core/File/IsReferenceTest.php" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.php" name="tests/Core/Filters/Filter/AcceptTest.php" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.xml" name="tests/Core/Filters/Filter/AcceptTest.xml" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
   </filelist>
@@ -1889,6 +1897,8 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <install as="CodeSniffer/Core/File/GetMethodPropertiesTest.inc" name="tests/Core/File/GetMethodPropertiesTest.inc" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.php" name="tests/Core/File/IsReferenceTest.php" />
    <install as="CodeSniffer/Core/File/IsReferenceTest.inc" name="tests/Core/File/IsReferenceTest.inc" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.php" name="tests/Core/Filters/Filter/AcceptTest.php" />
+   <install as="CodeSniffer/Core/Filters/Filter/AcceptTest.xml" name="tests/Core/Filters/Filter/AcceptTest.xml" />
    <install as="CodeSniffer/Standards/AllSniffs.php" name="tests/Standards/AllSniffs.php" />
    <install as="CodeSniffer/Standards/AbstractSniffUnitTest.php" name="tests/Standards/AbstractSniffUnitTest.php" />
    <ignore name="bin/phpcs.bat" />

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -229,6 +229,11 @@ class Filter extends \RecursiveFilterIterator
         }
 
         foreach ($ignorePatterns as $pattern => $type) {
+            // Ignore standard/sniff specific exclude rules.
+            if (is_array($type) === true) {
+                continue;
+            }
+
             // Maintains backwards compatibility in case the ignore pattern does
             // not have a relative/absolute value.
             if (is_int($pattern) === true) {

--- a/tests/Core/Filters/Filter/AcceptTest.inc
+++ b/tests/Core/Filters/Filter/AcceptTest.inc
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>The coding standard for PHP_CodeSniffer itself.</description>
-
-    <rule ref="Generic">
-        <exclude-pattern>/anything/</exclude-pattern>
-    </rule>
-</ruleset>

--- a/tests/Core/Filters/Filter/AcceptTest.xml
+++ b/tests/Core/Filters/Filter/AcceptTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AcceptTest" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>Ruleset to test the filtering based on exclude patterns.</description>
+
+	<!-- Directory pattern. -->
+	<exclude-pattern>*/something/*</exclude-pattern>
+	<!-- File pattern. -->
+	<exclude-pattern>*/Other/Main\.php$</exclude-pattern>
+
+    <rule ref="Generic">
+    	<!-- Standard specific directory pattern. -->
+        <exclude-pattern>/anything/*</exclude-pattern>
+    	<!-- Standard specific file pattern. -->
+        <exclude-pattern>/YetAnother/Main\.php</exclude-pattern>
+    </rule>
+</ruleset>


### PR DESCRIPTION
The file list filtering in the `Filter` class should only take global exclude patterns into account and should ignore sniff specific exclude patterns, which are used/handled in the `File::addMessage()` method.

This commit fixes this.

Includes:
* Reworking the initial unit test to use `setUpBeforeClass()` for the fixtures and a data provider to easily allow for more test cases without code duplication.
* Adding an additional unit test to verify that top-level exclude patterns are correctly respected.
* Renaming the test ruleset file to use the `xml` file extension.
* Adding the newly introduced unit test files to the `package.xml` file lists.

Fixes https://github.com/squizlabs/PHP_CodeSniffer/issues/2391